### PR TITLE
Get correct latest AMI

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -65,3 +65,8 @@ output "eks_worker_autoscaling_group_ids" {
 output "eks_worker_autoscaling_group_arn" {
   value = aws_autoscaling_group.eks-worker-cluster.*.arn
 }
+
+output "eks_version" {
+  value       = aws_eks_cluster.eks-master.version
+  description = "The Kubernetes server version for the cluster."
+}

--- a/workers.tf
+++ b/workers.tf
@@ -102,20 +102,14 @@ locals {
 
 }
 
-data "aws_ami" "eks-worker-ami" {
-  filter {
-    name   = "name"
-    values = ["amazon-eks-node-v*"]
-  }
-
-  most_recent = true
-  owners      = ["602401143452"] # Amazon Account ID
+data "aws_ssm_parameter" "eks_worker_ami" {
+  name = "/aws/service/eks/optimized-ami/${regex("[\\d]*.[\\d]*", aws_eks_cluster.eks-master.version)}/amazon-linux-2/recommended/image_id"
 }
 
 resource "aws_launch_configuration" "eks-worker-cluster" {
   count                = length(var.nodes)
   iam_instance_profile = aws_iam_instance_profile.eks-worker.name
-  image_id             = var.node_ami_id != "" ? var.node_ami_id : data.aws_ami.eks-worker-ami.id
+  image_id             = var.node_ami_id != "" ? var.node_ami_id : data.aws_ssm_parameter.eks_worker_ami.value
   instance_type        = var.nodes[count.index]["instance_type"]
   name_prefix          = "eks-cluster"
   security_groups      = [aws_security_group.eks-worker.id]


### PR DESCRIPTION
# Pull Request

## Description

* Change to new way of getting correct latest AMI from global parameter store
This stop the module picking the last updated ami (which could be Windows!)

Fixes # (issue)

### Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist

- [X] `terraform fmt` and `terraform validate` both work from the root and `examples/` directories (look in CI for an example)
- [ ] Provide an updated example that utilizes newly created resources, or for more advanced additions a new example under the examples directory.
- [ ] Example plan output in this PR (in lieu of CI)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Any breaking changes are noted in the description above
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] My code follows the style guidelines of this project
- [ ] Any dependent changes have been merged and published in downstream modules